### PR TITLE
监听qtk.Events.POINTER_LEAVE的bug.

### DIFF
--- a/src/controls/widget.ts
+++ b/src/controls/widget.ts
@@ -360,7 +360,6 @@ export class Widget extends Emitter {
 				this.onpointermove(evt);
 			}
 			this.dispatchEvent(evt, false);
-			this.state = WidgetState.NORMAL;
 		}
 
 		ctx.restore();


### PR DESCRIPTION
Do not set widget state to WidgetState.NORMAL since this will be done in Widget.prototype.dispatchPointerLeave.